### PR TITLE
Change iteration from 'last' to 'previous'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,6 @@ jobs:
         number: 1
         token: ${{ secrets.ITERATIONACTION }}
         iteration-field: Iteration
-        iteration: last
+        iteration: previous
         new-iteration: current
         excluded-statuses: "Done"


### PR DESCRIPTION
"last" wurde nicht gefunden und der Workflow ist deshalb gefailt. @previous ist der genutzte Tag innerhalb des Sprints.