### PR TITLE
Update token secret for move-to-next-iteration action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         owner: projekt-bht
         number: 1
-        token: ${{ secrets.ITERATIONACTION }}
+        token: ${{ secrets.MOVETONEXTITERATION }}
         iteration-field: Iteration
         iteration: last
         new-iteration: current


### PR DESCRIPTION
Vermutlich passten die Rechte vom Token nicht. Dieser hat jetzt auch die Orga.  read:write Rechte.